### PR TITLE
Add retry count to reconnect after a connection gets lost

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -15,6 +15,7 @@ export function startBot(storePath, debug, transClientId, transClientSec) {
   });
   controller.spawn({
     token: process.env.token,
+    retry: 10,
   }).startRTM();
   chuck(controller);
   taunt(controller);


### PR DESCRIPTION
Slack closes the connection to slack bots after they have been quiet for a while [[1]](https://github.com/howdyai/botkit/issues/104).

This PR adds a retry count to let the bot reconnect after it has been disconnected, since automatic retries are [disabled by default](https://github.com/howdyai/botkit/blob/b7c15e85c43ea539e0b4eacbd77ee5409bfcb4da/readme-slack.md#controllerspawn). 
